### PR TITLE
Fix rotation calculation

### DIFF
--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -177,10 +177,10 @@ Vector4 Converter::EulerToQuatRot(Vector3 euler)
 	float sr = (float)qSin(euler.getX() * 0.5);
 
 	return Vector4(
-		sr * cp * cy - cr * sp * sy,
-		cr * sp * cy + sr * cp * sy,
-		cr * cp * sy - sr * sp * cy,
-		cr * cp * cy + sr * sp * sy
+		sr * cp * cy + cr * sp * sy,
+		cr * sp * cy - sr * cp * sy,
+		cr * cp * sy + sr * sp * cy,
+		cr * cp * cy - sr * sp * sy
 	);
 }
 


### PR DESCRIPTION
Flip the order the axes are rotated (X axis first rather than Z axis).

#1 