### PR TITLE
Add filtering options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
 	src/main.cpp
 	src/converter.cpp
 	src/trigger-data.cpp
+	src/types.cpp
 	src/binary-io/data-stream.cpp
 	)
 

--- a/include/binary-io/data-stream.h
+++ b/include/binary-io/data-stream.h
@@ -36,7 +36,7 @@ public:
 		return s;
 	}
 
-	// callocs and reads data from the stream using DataStream's operator>>(DataStream&, T&) method
+	// callocs and reads data from the stream using DataStream's operator>>(DataStream&, T&)
 	template <typename T>
 	void cAllocAndQtRead(T*& entries, int count)
 	{
@@ -47,7 +47,7 @@ public:
 			*this >> entries[i];
 	}
 
-	// callocs and reads data from the stream using T's read(DataStream&) method
+	// callocs and reads data from the stream using T's read(DataStream&)
 	template <typename T>
 	void cAllocAndCustomRead(T*& entries, int count)
 	{
@@ -68,7 +68,8 @@ public:
 	// Reads a specified number of bytes from this stream to another stream, writing to a specified
 	// offset in the other stream. By default, this offset is the current offset of this stream.
 	// This is most useful for storing unknown data and padding to prevent data loss
-	void readRawData(DataStream& stream, quint32 length, qint64 position = -1);
+	// TODO: Come up with a more accurate name for this
+	void readRawData(DataStream& other, quint32 length, qint64 position = -1);
 
 	// Get the current offset the device is reading/writing from
 	qint64 pos();

--- a/include/converter.h
+++ b/include/converter.h
@@ -26,8 +26,10 @@ private:
 	std::string inFileName;
 	std::string outFileName;
 	uint8_t typeFilter = -1;
+	std::string profileFileName;
 
 	TriggerData* triggerData = nullptr;
+	QList<uint64_t> hitTriggerIds;
 
 	const int minArgCount = 3;
 	int getArgs(int argc, char* argv[]);
@@ -35,6 +37,7 @@ private:
 	void showUsage();
 
 	void readTriggerData();
+	void readProfileTriggers();
 	Buffer createGLTFBuffer();
 	void writeBoxRegion(DataStream& stream);
 	Vector4 EulerToQuatRot(Vector3 euler);

--- a/include/converter.h
+++ b/include/converter.h
@@ -21,6 +21,15 @@ public:
 	int result = 0;
 
 private:
+	enum class Platform
+	{
+		PS3,
+		X360,
+		PC,
+		PS4,
+		NX
+	} platform = Platform::PC;
+
 	// For file reading
 	DataStream inStream;
 	std::string inFileName;
@@ -38,6 +47,8 @@ private:
 
 	void readTriggerData();
 	void readProfileTriggers();
+	void readStuntElements(DataStream& stream, int offset, int count);
+	void readIslandStuntElements(DataStream& stream, int offset, int count);
 	Buffer createGLTFBuffer();
 	void writeBoxRegion(DataStream& stream);
 	Vector4 EulerToQuatRot(Vector3 euler);

--- a/include/converter.h
+++ b/include/converter.h
@@ -9,6 +9,9 @@
 
 #include <string>
 
+using namespace BrnTrigger;
+using namespace tinygltf;
+
 class Converter
 {
 public:
@@ -23,34 +26,35 @@ private:
 	std::string inFileName;
 	std::string outFileName;
 
-	BrnTrigger::TriggerData* triggerData = nullptr;
+	TriggerData* triggerData = nullptr;
 
+	const int minArgCount = 3;
 	int getArgs(int argc, char* argv[]);
 	int checkArgs(int argc, char* argv[]);
 	void showUsage();
 
 	void readTriggerData();
-	tinygltf::Buffer createGLTFBuffer();
+	Buffer createGLTFBuffer();
 	void writeBoxRegion(DataStream& stream);
 	Vector4 EulerToQuatRot(Vector3 euler);
 	void convertTriggersToGLTF();
 
-	bool triggerRegionExists(BrnTrigger::TriggerRegion region, bool checkGenericRegions = true);
-	void addTriggerRegionFields(BrnTrigger::TriggerRegion region, tinygltf::Value::Object& extras);
+	bool triggerRegionExists(TriggerRegion region, bool checkGenericRegions = true);
+	void addTriggerRegionFields(TriggerRegion region, Value::Object& extras);
 
-	void convertLandmark(BrnTrigger::Landmark landmark, tinygltf::Node& node, int index);
-	void convertStartingGrid(BrnTrigger::StartingGrid grid, tinygltf::Node& node, int index);
-	void convertBlackspot(BrnTrigger::Blackspot blackspot, tinygltf::Node& node, int index);
-	void convertVfxBoxRegion(BrnTrigger::VFXBoxRegion vfxBoxRegion, tinygltf::Node& node, int index);
-	void convertSignatureStunt(BrnTrigger::SignatureStunt signatureStunt, tinygltf::Node& node, int index);
-	void convertKillzone(BrnTrigger::Killzone killzone, tinygltf::Node& node, int index);
-	void convertGenericRegion(BrnTrigger::GenericRegion region, tinygltf::Node& node, int index);
-	void convertTriggerRegion(BrnTrigger::TriggerRegion triggerRegion, tinygltf::Node& node, int index);
-	void convertRoamingLocation(BrnTrigger::RoamingLocation location, tinygltf::Node& node, int index);
-	void convertSpawnLocation(BrnTrigger::SpawnLocation location, tinygltf::Node& node, int index);
+	void convertLandmark(Landmark landmark, Node& node, int index);
+	void convertStartingGrid(StartingGrid grid, Node& node, int index);
+	void convertBlackspot(Blackspot blackspot, Node& node, int index);
+	void convertVfxBoxRegion(VFXBoxRegion vfxBoxRegion, Node& node, int index);
+	void convertSignatureStunt(SignatureStunt signatureStunt, Node& node, int index);
+	void convertKillzone(Killzone killzone, Node& node, int index);
+	void convertGenericRegion(GenericRegion region, Node& node, int index);
+	void convertTriggerRegion(TriggerRegion triggerRegion, Node& node, int index);
+	void convertRoamingLocation(RoamingLocation location, Node& node, int index);
+	void convertSpawnLocation(SpawnLocation location, Node& node, int index);
 
 	template <typename T>
-	void addBoxRegionTransform(T entry, tinygltf::Node& node)
+	void addBoxRegionTransform(T entry, Node& node)
 	{
 		node.translation = {
 			entry.getBoxRegion().getPosX(),
@@ -75,7 +79,7 @@ private:
 		};
 	}
 
-	void addPointTransform(Vector3 pos, Vector3 rot, tinygltf::Node& node)
+	void addPointTransform(Vector3 pos, Vector3 rot, Node& node)
 	{
 		node.translation = {
 			pos.getX(),
@@ -95,7 +99,7 @@ private:
 		};
 	}
 
-	void addPointTransform(Vector3 pos, tinygltf::Node& node)
+	void addPointTransform(Vector3 pos, Node& node)
 	{
 		node.translation = {
 			pos.getX(),

--- a/include/converter.h
+++ b/include/converter.h
@@ -34,7 +34,7 @@ private:
 	DataStream inStream;
 	std::string inFileName;
 	std::string outFileName;
-	uint8_t typeFilter = -1;
+	int8_t typeFilter = -1;
 	std::string profileFileName;
 
 	TriggerData* triggerData = nullptr;

--- a/include/converter.h
+++ b/include/converter.h
@@ -25,6 +25,7 @@ private:
 	DataStream inStream;
 	std::string inFileName;
 	std::string outFileName;
+	uint8_t typeFilter = -1;
 
 	TriggerData* triggerData = nullptr;
 

--- a/include/converter.h
+++ b/include/converter.h
@@ -57,54 +57,54 @@ private:
 	void addBoxRegionTransform(T entry, Node& node)
 	{
 		node.translation = {
-			entry.getBoxRegion().getPosX(),
-			entry.getBoxRegion().getPosY(),
-			entry.getBoxRegion().getPosZ()
+			entry.boxRegion.positionX,
+			entry.boxRegion.positionY,
+			entry.boxRegion.positionZ
 		};
 		Vector4 rotation = EulerToQuatRot({
-			entry.getBoxRegion().getRotX(),
-			entry.getBoxRegion().getRotY(),
-			entry.getBoxRegion().getRotZ()
+			entry.boxRegion.rotationX,
+			entry.boxRegion.rotationY,
+			entry.boxRegion.rotationZ
 		});
 		node.rotation = {
-			rotation.getX(),
-			rotation.getY(),
-			rotation.getZ(),
-			rotation.getW()
+			rotation.x,
+			rotation.y,
+			rotation.z,
+			rotation.w
 		};
 		node.scale = {
-			entry.getBoxRegion().getDimX(),
-			entry.getBoxRegion().getDimY(),
-			entry.getBoxRegion().getDimZ()
+			entry.boxRegion.dimensionX,
+			entry.boxRegion.dimensionY,
+			entry.boxRegion.dimensionZ
 		};
 	}
 
 	void addPointTransform(Vector3 pos, Vector3 rot, Node& node)
 	{
 		node.translation = {
-			pos.getX(),
-			pos.getY(),
-			pos.getZ()
+			pos.x,
+			pos.y,
+			pos.z
 		};
 		Vector4 rotation = EulerToQuatRot({
-			rot.getX(),
-			rot.getY(),
-			rot.getZ()
+			rot.x,
+			rot.y,
+			rot.z
 		});
 		node.rotation = {
-			rotation.getX(),
-			rotation.getY(),
-			rotation.getZ(),
-			rotation.getW()
+			rotation.x,
+			rotation.y,
+			rotation.z,
+			rotation.w
 		};
 	}
 
 	void addPointTransform(Vector3 pos, Node& node)
 	{
 		node.translation = {
-			pos.getX(),
-			pos.getY(),
-			pos.getZ()
+			pos.x,
+			pos.y,
+			pos.z
 		};
 	}
 };

--- a/include/trigger-data.h
+++ b/include/trigger-data.h
@@ -4,23 +4,13 @@
 
 namespace BrnTrigger
 {
-	// Box trigger type. Sphere and line types are not supported.
-	class BoxRegion
+	// Transform for box triggers.
+	// Sphere and line types are not supported.
+	struct BoxRegion
 	{
-	public:
-		void read(DataStream& file);
+		void read(DataStream& in);
+		void write(DataStream& out);
 
-		float getPosX() { return positionX; }
-		float getPosY() { return positionY; }
-		float getPosZ() { return positionZ; }
-		float getRotX() { return rotationX; }
-		float getRotY() { return rotationY; }
-		float getRotZ() { return rotationZ; }
-		float getDimX() { return dimensionX; }
-		float getDimY() { return dimensionY; }
-		float getDimZ() { return dimensionZ; }
-
-	private:
 		float32_t positionX = 0;
 		float32_t positionY = 0;
 		float32_t positionZ = 0;
@@ -32,22 +22,9 @@ namespace BrnTrigger
 		float32_t dimensionZ = 0;
 	};
 
-	// The actual data for the trigger. Used on nearly all types.
-	class TriggerRegion
+	// General container for box triggers.
+	struct TriggerRegion
 	{
-		enum class Type : uint8_t;
-
-	public:
-		void read(DataStream& file);
-
-		BoxRegion getBoxRegion() { return boxRegion; }
-		int32_t getId() { return id; }
-		int16_t getRegionIndex() { return regionIndex; }
-		Type getType() { return type; }
-		uint8_t getUnk0() { return unk0; }
-
-	private:
-		// The type of trigger region.
 		enum class Type : uint8_t
 		{
 			landmark,
@@ -55,6 +32,9 @@ namespace BrnTrigger
 			genericRegion,
 			vfxBoxRegion
 		};
+
+		void read(DataStream& file);
+		void write(DataStream& file);
 
 		BoxRegion boxRegion;
 		int32_t id = 0;
@@ -64,43 +44,29 @@ namespace BrnTrigger
 	};
 
 	// Starting grid for race events. Unused in retail.
-	class StartingGrid
+	struct StartingGrid
 	{
 	public:
 		StartingGrid();
 
 		void read(DataStream& file);
+		void write(DataStream& file);
 
-		Vector3 getStartingPosition(int index) { return startingPositions[index]; }
-		Vector3 getStartingDirection(int index) { return startingDirections[index]; }
-
-	private:
 		Vector3 startingPositions[8];
 		Vector3 startingDirections[8];
 	};
 
-	// Used for finish lines and event starts.
+	// Used for finish lines and checkpoints (but not event starts).
 	// Big Surf Island has an overabundance of Landmarks.
-	class Landmark : public TriggerRegion
+	struct Landmark : public TriggerRegion
 	{
-		enum class Flags : uint8_t;
-
-	public:
-		void read(DataStream& file);
-
-		StartingGrid getStartingGrid(int index) { return startingGrids[index]; }
-		int8_t getStartingGridCount() { return startingGridCount; }
-		uint8_t getDesignIndex() { return designIndex; }
-		uint8_t getDistrict() { return district; }
-		Flags getFlags() { return flags; }
-		bool getIsOnline() { return ((uint8_t)flags & (uint8_t)Flags::isOnline) != 0; };
-
-	private:
-		// The flags field in the Landmark structure.
 		enum class Flags : uint8_t
 		{
 			isOnline = 1 << 0
 		};
+
+		void read(DataStream& file);
+		void write(DataStream& file);
 
 		StartingGrid* startingGrids;
 		int8_t startingGridCount = 0;
@@ -109,25 +75,9 @@ namespace BrnTrigger
 		Flags flags = (Flags)0;
 	};
 
-	// Generic box trigger. The main trigger type used. Used for many things.
-	class GenericRegion : public TriggerRegion
+	// Generic box trigger. This is the main trigger type used by the game.
+	struct GenericRegion : public TriggerRegion
 	{
-		enum class StuntCameraType : int8_t;
-		enum class Type : uint8_t;
-
-	public:
-		void read(DataStream& file);
-
-		int32_t getGroupId() { return groupId; }
-		int16_t getCameraCut1() { return cameraCut1; }
-		int16_t getCameraCut2() { return cameraCut2; }
-		StuntCameraType getcameraType1() { return cameraType1; }
-		StuntCameraType getcameraType2() { return cameraType2; }
-		Type getType() { return type; }
-		int8_t getIsOneWay() { return isOneWay; }
-
-	private:
-		// Camera type used on GenericRegion stunts.
 		enum class StuntCameraType : int8_t
 		{
 			noCuts,
@@ -135,8 +85,6 @@ namespace BrnTrigger
 			normal
 		};
 
-		// The type of generic region. Uses include audio, drivethru, and camera
-		// triggers, among others.
 		enum class Type : uint8_t
 		{
 			junkyard,
@@ -173,6 +121,9 @@ namespace BrnTrigger
 			ramp
 		};
 
+		void read(DataStream& file);
+		void write(DataStream& file);
+
 		int32_t groupId = 0; // GameDB ID
 		int16_t cameraCut1 = 0;
 		int16_t cameraCut2 = 0;
@@ -183,47 +134,37 @@ namespace BrnTrigger
 	};
 
 	// Accident blackspot (crash mode). Unused in retail.
-	class Blackspot : public TriggerRegion
+	struct Blackspot : public TriggerRegion
 	{
-		enum class ScoreType : uint8_t;
-
-	public:
-		void read(DataStream& file);
-
-		ScoreType getScoreType() { return scoreType; }
-		int32_t getScoreAmount() { return scoreAmount; }
-
-	private:
-		// The Blackspot scoring system. Note that both are used in Showtime.
 		enum class ScoreType : uint8_t
 		{
 			distance,
 			carCount
 		};
 
+		void read(DataStream& file);
+		void write(DataStream& file);
+
 		ScoreType scoreType = (ScoreType)0;
 		int32_t scoreAmount = 0;
 	};
 
 	// VFX region. Unused in retail.
-	class VFXBoxRegion : public TriggerRegion
+	struct VFXBoxRegion : public TriggerRegion
 	{
-	public:
 		void read(DataStream& file);
+		void write(DataStream& file);
 	};
 
 	// TODO: Description
-	class SignatureStunt
+	struct SignatureStunt
 	{
-	public:
 		void read(DataStream& file);
+		void write(DataStream& file);
 
-		CgsID getId() { return id; }
-		int64_t getCamera() { return camera; }
 		GenericRegion getStuntElement(int index) { return stuntElements[index][0]; }
-		int32_t getStuntElementCount() { return stuntElementCount; }
+		void setStuntElement(GenericRegion region, int index) { stuntElements[index][0] = region; }
 
-	private:
 		CgsID id = 0;
 		int64_t camera = 0;
 		GenericRegion** stuntElements = nullptr;
@@ -231,17 +172,14 @@ namespace BrnTrigger
 	};
 
 	// TODO: Description
-	class Killzone
+	struct Killzone
 	{
-	public:
 		void read(DataStream& file);
+		void write(DataStream& file);
 
 		GenericRegion getTrigger(int index) { return triggers[index][0]; }
-		int32_t getTriggerCount() { return triggerCount; }
-		CgsID getRegionId(int index) { return regionIds[index]; }
-		int32_t getRegionIdCount() { return regionIdCount; }
+		void setTrigger(GenericRegion region, int index) { triggers[index][0] = region; }
 
-	private:
 		GenericRegion** triggers = nullptr;
 		int32_t triggerCount = 0;
 		CgsID* regionIds = nullptr; // GameDB IDs
@@ -249,34 +187,18 @@ namespace BrnTrigger
 	};
 
 	// Spawn locations for roaming rivals (shutdown cars)
-	class RoamingLocation
+	struct RoamingLocation
 	{
-	public:
 		void read(DataStream& file);
+		void write(DataStream& file);
 
-		Vector3 getPosition() { return position; }
-		uint8_t getDistrictIndex() { return districtIndex; }
-
-	private:
 		Vector3 position = Vector3(true);
 		uint8_t districtIndex = 0;
 	};
 
 	// Vehicle spawn locations in and outside each Junkyard
-	class SpawnLocation
+	struct SpawnLocation
 	{
-		enum class Type : uint8_t;
-
-	public:
-		void read(DataStream& file);
-
-		Vector3 getPosition() { return position; }
-		Vector3 getDirection() { return direction; }
-		CgsID getJunkyardId() { return junkyardId; }
-		Type getType() { return type; }
-
-	private:
-		// The type of spawn at a spawn location.
 		enum class Type : uint8_t
 		{
 			playerSpawn,
@@ -284,6 +206,9 @@ namespace BrnTrigger
 			carSelectRight,
 			carUnlock
 		};
+
+		void read(DataStream& file);
+		void write(DataStream& file);
 
 		Vector3 position = Vector3(true);
 		Vector3 direction = Vector3(true);
@@ -293,36 +218,14 @@ namespace BrnTrigger
 
 	// The header for the TriggerData resource.
 	// Lists all relevant offsets and counts.
-	class TriggerData
+	struct TriggerData
 	{
-	public:
 		void read(DataStream& file);
+		void write(DataStream& file);
 
-		int32_t getVersionNumber() { return versionNumber; }
-		uint32_t getSize() { return size; }
-		Vector3 getPlayerStartPosition() { return playerStartPosition; }
-		Vector3 getPlayerStartDirection() { return playerStartDirection; }
-		Landmark getLandmark(int index) { return landmarks[index]; }
-		int32_t getLandmarkCount() { return landmarkCount; }
-		int32_t getOnlineLandmarkCount() { return onlineLandmarkCount; }
-		SignatureStunt getSignatureStunt(int index) { return signatureStunts[index]; }
-		int32_t getSignatureStuntCount() { return signatureStuntCount; }
-		GenericRegion getGenericRegion(int index) { return genericRegions[index]; }
-		int32_t getGenericRegionCount() { return genericRegionCount; }
-		Killzone getKillzone(int index) { return killzones[index]; }
-		int32_t getKillzoneCount() { return killzoneCount; }
-		Blackspot getBlackspot(int index) { return blackspots[index]; }
-		int32_t getBlackspotCount() { return blackspotCount; }
-		VFXBoxRegion getVfxBoxRegion(int index) { return vfxBoxRegions[index]; }
-		int32_t getVfxBoxRegionCount() { return vfxBoxRegionCount; }
-		RoamingLocation getRoamingLocation(int index) { return roamingLocations[index]; }
-		int32_t getRoamingLocationCount() { return roamingLocationCount; }
-		SpawnLocation getSpawnLocation(int index) { return spawnLocations[index]; }
-		int32_t getSpawnLocationCount() { return spawnLocationCount; }
-		TriggerRegion getTriggerRegion(int index) { return regions[index][0]; }
-		int32_t getRegionCount() { return regionCount; }
+		TriggerRegion getRegion(int index) { return regions[index][0]; }
+		void setRegion(TriggerRegion region, int index) { regions[index][0] = region; }
 
-	private:
 		int32_t versionNumber = 0;
 		uint32_t size = 0;
 		Vector3 playerStartPosition = Vector3(true);
@@ -336,7 +239,6 @@ namespace BrnTrigger
 		int32_t genericRegionCount = 0;
 		Killzone* killzones = nullptr;
 		int32_t killzoneCount = 0;
-		Blackspot* fileBlackspots = nullptr;
 		Blackspot* blackspots = nullptr;
 		int32_t blackspotCount = 0;
 		VFXBoxRegion* vfxBoxRegions = nullptr;

--- a/include/trigger-data.h
+++ b/include/trigger-data.h
@@ -4,73 +4,6 @@
 
 namespace BrnTrigger
 {
-	// Forward declare classes
-	class Landmark;
-	class SignatureStunt;
-	class GenericRegion;
-	class Killzone;
-	class Blackspot;
-	class VFXBoxRegion;
-	class RoamingLocation;
-	class SpawnLocation;
-	class TriggerRegion;
-	class StartingGrid;
-
-	// The header for the TriggerData resource.
-	// Lists all relevant offsets and counts.
-	class TriggerData
-	{
-	public:
-		void read(DataStream& file);
-
-		Landmark getLandmark(int index);
-		SignatureStunt getSignatureStunt(int index);
-		GenericRegion getGenericRegion(int index);
-		Killzone getKillzone(int index);
-		Blackspot getBlackspot(int index);
-		VFXBoxRegion getVfxBoxRegion(int index);
-		RoamingLocation getRoamingLocation(int index);
-		SpawnLocation getSpawnLocation(int index);
-		TriggerRegion getTriggerRegion(int index);
-
-		int32_t getLandmarkCount() { return landmarkCount; }
-		int32_t getSignatureStuntCount() { return signatureStuntCount; }
-		int32_t getGenericRegionCount() { return genericRegionCount; }
-		int32_t getKillzoneCount() { return killzoneCount; }
-		int32_t getBlackspotCount() { return blackspotCount; }
-		int32_t getVfxBoxRegionCount() { return vfxBoxRegionCount; }
-		int32_t getRoamingLocationCount() { return roamingLocationCount; }
-		int32_t getSpawnLocationCount() { return spawnLocationCount; }
-		int32_t getRegionCount() { return regionCount; }
-		int32_t getTotalRegionCount();
-
-	private:
-		int32_t versionNumber = 0;
-		uint32_t size = 0;
-		Vector3 playerStartPosition;
-		Vector3 playerStartDirection;
-		Landmark* landmarks = nullptr;
-		int32_t landmarkCount = 0;
-		int32_t onlineLandmarkCount = 0;
-		SignatureStunt* signatureStunts = nullptr;
-		int32_t signatureStuntCount = 0;
-		GenericRegion* genericRegions = nullptr;
-		int32_t genericRegionCount = 0;
-		Killzone* killzones = nullptr;
-		int32_t killzoneCount = 0;
-		Blackspot* fileBlackspots = nullptr;
-		Blackspot* blackspots = nullptr;
-		int32_t blackspotCount = 0;
-		VFXBoxRegion* vfxBoxRegions = nullptr;
-		int32_t vfxBoxRegionCount = 0;
-		RoamingLocation* roamingLocations = nullptr;
-		int32_t roamingLocationCount = 0;
-		SpawnLocation* spawnLocations = nullptr;
-		int32_t spawnLocationCount = 0;
-		TriggerRegion** regions = nullptr;
-		int32_t regionCount = 0;
-	};
-
 	// Box trigger type. Sphere and line types are not supported.
 	class BoxRegion
 	{
@@ -125,13 +58,29 @@ namespace BrnTrigger
 
 		BoxRegion boxRegion;
 		int32_t id = 0;
-		int16_t regionIndex = 0; // Landmarks come after GenericRegions
+		int16_t regionIndex = 0;
 		Type type = (Type)0;
-		uint8_t unk0 = 0; // Flags? 0 or 1. No longer padding
+		uint8_t unk0 = 0; // Flags? 0 or 1. No longer padding. TODO: Find out what version introduced this
 	};
 
-	// Used for finish lines and event starts. Big Surf Island has an
-	// overabundance of Landmarks.
+	// Starting grid for race events. Unused in retail.
+	class StartingGrid
+	{
+	public:
+		StartingGrid();
+
+		void read(DataStream& file);
+
+		Vector3 getStartingPosition(int index) { return startingPositions[index]; }
+		Vector3 getStartingDirection(int index) { return startingDirections[index]; }
+
+	private:
+		Vector3 startingPositions[8];
+		Vector3 startingDirections[8];
+	};
+
+	// Used for finish lines and event starts.
+	// Big Surf Island has an overabundance of Landmarks.
 	class Landmark : public TriggerRegion
 	{
 		enum class Flags : uint8_t;
@@ -139,13 +88,12 @@ namespace BrnTrigger
 	public:
 		void read(DataStream& file);
 
-		StartingGrid getStartingGrid(int index);
+		StartingGrid getStartingGrid(int index) { return startingGrids[index]; }
+		int8_t getStartingGridCount() { return startingGridCount; }
 		uint8_t getDesignIndex() { return designIndex; }
 		uint8_t getDistrict() { return district; }
 		Flags getFlags() { return flags; }
 		bool getIsOnline() { return ((uint8_t)flags & (uint8_t)Flags::isOnline) != 0; };
-
-		int8_t getStartingGridCount() { return startingGridCount; }
 
 	private:
 		// The flags field in the Landmark structure.
@@ -159,39 +107,6 @@ namespace BrnTrigger
 		uint8_t designIndex = 0; // Landmark-only index
 		uint8_t district = 0;
 		Flags flags = (Flags)0;
-	};
-
-	// Starting grid for race events. Unused in retail.
-	class StartingGrid
-	{
-	public:
-		void read(DataStream& file);
-
-		Vector3 getStartingPosition(int index) { return startingPositions[index]; }
-		Vector3 getStartingDirection(int index) { return startingDirections[index]; }
-
-	private:
-		Vector3 startingPositions[8];
-		Vector3 startingDirections[8];
-	};
-
-	// 
-	class SignatureStunt
-	{
-	public:
-		void read(DataStream& file);
-
-		CgsID getId() { return id; }
-		int64_t getCamera() { return camera; }
-		GenericRegion getStuntElement(int index);
-
-		int32_t getStuntElementCount() { return stuntElementCount; }
-
-	private:
-		CgsID id = 0;
-		int64_t camera = 0;
-		GenericRegion** stuntElements = nullptr;
-		int32_t stuntElementCount = 0;
 	};
 
 	// Generic box trigger. The main trigger type used. Used for many things.
@@ -267,25 +182,6 @@ namespace BrnTrigger
 		int8_t isOneWay = 0;
 	};
 
-	// TODO: Description
-	class Killzone
-	{
-	public:
-		void read(DataStream& file);
-
-		GenericRegion getTrigger(int index) { return triggers[index][0]; }
-		CgsID getRegionId(int index) { return regionIds[index]; }
-
-		int32_t getTriggerCount() { return triggerCount; }
-		int32_t getRegionIdCount() { return regionIdCount; }
-
-	private:
-		GenericRegion** triggers = nullptr;
-		int32_t triggerCount = 0;
-		CgsID* regionIds = nullptr; // GameDB IDs
-		int32_t regionIdCount = 0;
-	};
-
 	// Accident blackspot (crash mode). Unused in retail.
 	class Blackspot : public TriggerRegion
 	{
@@ -314,9 +210,42 @@ namespace BrnTrigger
 	{
 	public:
 		void read(DataStream& file);
+	};
+
+	// TODO: Description
+	class SignatureStunt
+	{
+	public:
+		void read(DataStream& file);
+
+		CgsID getId() { return id; }
+		int64_t getCamera() { return camera; }
+		GenericRegion getStuntElement(int index) { return stuntElements[index][0]; }
+		int32_t getStuntElementCount() { return stuntElementCount; }
 
 	private:
+		CgsID id = 0;
+		int64_t camera = 0;
+		GenericRegion** stuntElements = nullptr;
+		int32_t stuntElementCount = 0;
+	};
 
+	// TODO: Description
+	class Killzone
+	{
+	public:
+		void read(DataStream& file);
+
+		GenericRegion getTrigger(int index) { return triggers[index][0]; }
+		int32_t getTriggerCount() { return triggerCount; }
+		CgsID getRegionId(int index) { return regionIds[index]; }
+		int32_t getRegionIdCount() { return regionIdCount; }
+
+	private:
+		GenericRegion** triggers = nullptr;
+		int32_t triggerCount = 0;
+		CgsID* regionIds = nullptr; // GameDB IDs
+		int32_t regionIdCount = 0;
 	};
 
 	// Spawn locations for roaming rivals (shutdown cars)
@@ -329,7 +258,7 @@ namespace BrnTrigger
 		uint8_t getDistrictIndex() { return districtIndex; }
 
 	private:
-		Vector3 position;
+		Vector3 position = Vector3(true);
 		uint8_t districtIndex = 0;
 	};
 
@@ -356,9 +285,67 @@ namespace BrnTrigger
 			carUnlock
 		};
 
-		Vector3 position;
-		Vector3 direction;
+		Vector3 position = Vector3(true);
+		Vector3 direction = Vector3(true);
 		CgsID junkyardId = 0; // GameDB ID
 		Type type = (Type)0;
+	};
+
+	// The header for the TriggerData resource.
+	// Lists all relevant offsets and counts.
+	class TriggerData
+	{
+	public:
+		void read(DataStream& file);
+
+		int32_t getVersionNumber() { return versionNumber; }
+		uint32_t getSize() { return size; }
+		Vector3 getPlayerStartPosition() { return playerStartPosition; }
+		Vector3 getPlayerStartDirection() { return playerStartDirection; }
+		Landmark getLandmark(int index) { return landmarks[index]; }
+		int32_t getLandmarkCount() { return landmarkCount; }
+		int32_t getOnlineLandmarkCount() { return onlineLandmarkCount; }
+		SignatureStunt getSignatureStunt(int index) { return signatureStunts[index]; }
+		int32_t getSignatureStuntCount() { return signatureStuntCount; }
+		GenericRegion getGenericRegion(int index) { return genericRegions[index]; }
+		int32_t getGenericRegionCount() { return genericRegionCount; }
+		Killzone getKillzone(int index) { return killzones[index]; }
+		int32_t getKillzoneCount() { return killzoneCount; }
+		Blackspot getBlackspot(int index) { return blackspots[index]; }
+		int32_t getBlackspotCount() { return blackspotCount; }
+		VFXBoxRegion getVfxBoxRegion(int index) { return vfxBoxRegions[index]; }
+		int32_t getVfxBoxRegionCount() { return vfxBoxRegionCount; }
+		RoamingLocation getRoamingLocation(int index) { return roamingLocations[index]; }
+		int32_t getRoamingLocationCount() { return roamingLocationCount; }
+		SpawnLocation getSpawnLocation(int index) { return spawnLocations[index]; }
+		int32_t getSpawnLocationCount() { return spawnLocationCount; }
+		TriggerRegion getTriggerRegion(int index) { return regions[index][0]; }
+		int32_t getRegionCount() { return regionCount; }
+
+	private:
+		int32_t versionNumber = 0;
+		uint32_t size = 0;
+		Vector3 playerStartPosition = Vector3(true);
+		Vector3 playerStartDirection = Vector3(true);
+		Landmark* landmarks = nullptr;
+		int32_t landmarkCount = 0;
+		int32_t onlineLandmarkCount = 0;
+		SignatureStunt* signatureStunts = nullptr;
+		int32_t signatureStuntCount = 0;
+		GenericRegion* genericRegions = nullptr;
+		int32_t genericRegionCount = 0;
+		Killzone* killzones = nullptr;
+		int32_t killzoneCount = 0;
+		Blackspot* fileBlackspots = nullptr;
+		Blackspot* blackspots = nullptr;
+		int32_t blackspotCount = 0;
+		VFXBoxRegion* vfxBoxRegions = nullptr;
+		int32_t vfxBoxRegionCount = 0;
+		RoamingLocation* roamingLocations = nullptr;
+		int32_t roamingLocationCount = 0;
+		SpawnLocation* spawnLocations = nullptr;
+		int32_t spawnLocationCount = 0;
+		TriggerRegion** regions = nullptr;
+		int32_t regionCount = 0;
 	};
 };

--- a/include/types.h
+++ b/include/types.h
@@ -9,40 +9,35 @@
 typedef float float32_t;
 typedef uint64_t CgsID;
 
-class Vector3
+struct Vector3
 {
-public:
 	Vector3(bool isVpu = false);
 	Vector3(float x, float y, float z, bool vpu = false);
 
 	void read(DataStream& stream);
+	void write(DataStream& stream);
 
-	float getX() { return x; }
-	float getY() { return y; }
-	float getZ() { return z; }
 	bool getIsVpu() { return isVpu; }
 
-private:
+	void setIsVpu(bool val) { isVpu = val; }
+
 	float x = 0;
 	float y = 0;
 	float z = 0;
+
+private:
 	bool isVpu = false;
 };
 
-class Vector4
+struct Vector4
 {
 public:
 	Vector4();
 	Vector4(float x, float y, float z, float w);
 
 	void read(DataStream& stream);
+	void write(DataStream& stream);
 
-	float getX() { return x; }
-	float getY() { return y; }
-	float getZ() { return z; }
-	float getW() { return w; }
-
-private:
 	float x = 0;
 	float y = 0;
 	float z = 0;

--- a/include/types.h
+++ b/include/types.h
@@ -12,66 +12,30 @@ typedef uint64_t CgsID;
 class Vector3
 {
 public:
-	Vector3()
-	{
-		
-	}
+	Vector3(bool isVpu = false);
+	Vector3(float x, float y, float z, bool vpu = false);
 
-	Vector3(float x, float y, float z)
-	{
-		this->x = x;
-		this->y = y;
-		this->z = z;
-	}
-
-	void readFPU(DataStream& file)
-	{
-		file >> x;
-		file >> y;
-		file >> z;
-	}
-
-	void readVPU(DataStream& file)
-	{
-		file >> x;
-		file >> y;
-		file >> z;
-		file.skip(0x4);
-	}
+	void read(DataStream& stream);
 
 	float getX() { return x; }
 	float getY() { return y; }
 	float getZ() { return z; }
+	bool getIsVpu() { return isVpu; }
 
 private:
 	float x = 0;
 	float y = 0;
 	float z = 0;
+	bool isVpu = false;
 };
 
 class Vector4
 {
 public:
-	Vector4()
-	{
+	Vector4();
+	Vector4(float x, float y, float z, float w);
 
-	}
-
-	Vector4(float x, float y, float z, float w)
-	{
-		this->x = x;
-		this->y = y;
-		this->z = z;
-		this->w = w;
-	}
-
-	void read(DataStream& file)
-	{
-		file >> x;
-		file >> y;
-		file >> z;
-		file >> w;
-	}
+	void read(DataStream& stream);
 
 	float getX() { return x; }
 	float getY() { return y; }
@@ -84,32 +48,3 @@ private:
 	float z = 0;
 	float w = 0;
 };
-
-// In-game districts
-// Not needed yet
-//enum class District
-//{
-//	oceanView,
-//	westAcres,
-//	twinBridges,
-//	bigSurfBeach,
-//	easternShore,
-//	hillsidePass,
-//	heartbreakHills,
-//	rockridgeCliffs,
-//	southBay,
-//	parkVale,
-//	paradiseWharf,
-//	crystalSummit,
-//	lonePeaks,
-//	sunsetValley,
-//	downtown,
-//	riverCity,
-//	motorCity,
-//	waterfront,
-//	paradiseKeysBridge,
-//	northBeach,
-//	midTown,
-//	southCoast,
-//	perrensPoint
-//};

--- a/src/binary-io/data-stream.cpp
+++ b/src/binary-io/data-stream.cpp
@@ -41,10 +41,10 @@ void DataStream::writeString(QString string, quint64 length)
 // offset in the other stream. By default, this offset is the current offset of this stream.
 // This is most useful for storing unknown data and padding to prevent data loss
 // TODO: Come up with a more accurate name for this
-void DataStream::readRawData(DataStream& stream, quint32 length, qint64 position)
+void DataStream::readRawData(DataStream& other, quint32 length, qint64 position)
 {
-	position != -1 ? stream.seek(position) : stream.seek(pos());
-	stream.device()->write(device()->read(length));
+	position != -1 ? other.seek(position) : other.seek(pos());
+	other.device()->write(device()->read(length));
 }
 
 // Get the current offset the device is reading/writing from

--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -53,6 +53,13 @@ int Converter::getArgs(int argc, char* argv[])
 				inStream.setIs64Bit(true);
 			i++;
 		}
+		else if (strcmp(argv[i], "-f") == 0)
+		{
+			uint8_t filter = atoi(argv[i + 1]);
+			if (filter >= 0)
+				typeFilter = filter;
+			i++;
+		}
 		else
 		{
 			std::cerr << "Invalid option specified: " << argv[i];
@@ -99,8 +106,9 @@ int Converter::checkArgs(int argc, char* argv[])
 
 void Converter::showUsage()
 {
-	std::cout << "Usage: TriggersToGLTF [-p PLATFORM] <input file> <output file>\n\n"
-		<< "Options:\n -p   File platform. PS3, X360, PC, PS4, or NX. Default: PC";
+	std::cout << "Usage: TriggersToGLTF [options] <input file> <output file>\n\n"
+		<< "Options:\n -p   File platform. PS3, X360, PC, PS4, or NX. Default: PC\n"
+		<< " -f   GenericRegion type filter (an integer number). By default, all are converted.";
 }
 
 void Converter::readTriggerData()
@@ -240,88 +248,13 @@ void Converter::convertTriggersToGLTF()
 	// Create nodes
 	// TriggerRegion derived nodes
 	int currentNodeCount = 0;
-	int landmarkNodeIndex = currentNodeCount;
-	int landmarkChildCount = 0;
-	for (int i = 0; i < triggerData->landmarkCount; ++i)
-	{
-		model->nodes.push_back(Node());
-		model->nodes.back().mesh = 0;
-		for (int j = 0; j < triggerData->landmarks[i].startingGridCount; ++j)
-		{
-			model->nodes.push_back(Node());
-			model->nodes.back().mesh = 0;
-			model->nodes[landmarkNodeIndex + i + landmarkChildCount].children.push_back(landmarkNodeIndex + i + landmarkChildCount + j + 1);
-			convertStartingGrid(triggerData->landmarks[i].startingGrids[j], model->nodes[landmarkNodeIndex + i + landmarkChildCount + j + 1], j);
-			currentNodeCount++;
-		}
-		convertLandmark(triggerData->landmarks[i], model->nodes[i + landmarkNodeIndex], i);
-		currentNodeCount++;
-		landmarkChildCount += triggerData->landmarks[i].startingGridCount;
-		model->scenes[0].nodes.push_back(landmarkNodeIndex + i + landmarkChildCount - triggerData->landmarks[i].startingGridCount);
-	}
-	int blackspotNodeIndex = currentNodeCount;
-	for (int i = 0; i < triggerData->blackspotCount; ++i)
-	{
-		model->nodes.push_back(Node());
-		model->nodes.back().mesh = 0;
-		convertBlackspot(triggerData->blackspots[i], model->nodes[blackspotNodeIndex + i], i);
-		currentNodeCount++;
-		model->scenes[0].nodes.push_back(blackspotNodeIndex + i);
-	}
-	int vfxBoxRegionNodeIndex = currentNodeCount;
-	for (int i = 0; i < triggerData->vfxBoxRegionCount; ++i)
-	{
-		model->nodes.push_back(Node());
-		model->nodes.back().mesh = 0;
-		convertVfxBoxRegion(triggerData->vfxBoxRegions[i], model->nodes[vfxBoxRegionNodeIndex + i], i);
-		currentNodeCount++;
-		model->scenes[0].nodes.push_back(vfxBoxRegionNodeIndex + i);
-	}
-
-	// Nodes with GenericRegion arrays
-	int signatureStuntNodeIndex = currentNodeCount;
-	int signatureStuntChildCount = 0;
-	for (int i = 0; i < triggerData->signatureStuntCount; ++i)
-	{
-		model->nodes.push_back(Node());
-		for (int j = 0; j < triggerData->signatureStunts[i].stuntElementCount; ++j)
-		{
-			model->nodes.push_back(Node());
-			model->nodes.back().mesh = 0;
-			model->nodes[signatureStuntNodeIndex + i + signatureStuntChildCount].children.push_back(signatureStuntNodeIndex + i + signatureStuntChildCount + j + 1);
-			convertGenericRegion(triggerData->signatureStunts[i].getStuntElement(j), model->nodes[signatureStuntNodeIndex + i + signatureStuntChildCount + j + 1], j);
-			currentNodeCount++;
-		}
-		convertSignatureStunt(triggerData->signatureStunts[i], model->nodes[signatureStuntNodeIndex + i + signatureStuntChildCount], i);
-		currentNodeCount++;
-		signatureStuntChildCount += triggerData->signatureStunts[i].stuntElementCount;
-		model->scenes[0].nodes.push_back(signatureStuntNodeIndex + i + signatureStuntChildCount - triggerData->signatureStunts[i].stuntElementCount);
-	}
-	int killzoneNodeIndex = currentNodeCount;
-	int killzoneChildCount = 0;
-	for (int i = 0; i < triggerData->killzoneCount; ++i)
-	{
-		model->nodes.push_back(Node());
-		for (int j = 0; j < triggerData->killzones[i].triggerCount; ++j)
-		{
-			model->nodes.push_back(Node());
-			model->nodes.back().mesh = 0;
-			model->nodes[killzoneNodeIndex + i + killzoneChildCount].children.push_back(killzoneNodeIndex + i + killzoneChildCount + j + 1);
-			convertGenericRegion(triggerData->killzones[i].getTrigger(j), model->nodes[killzoneNodeIndex + i + killzoneChildCount + j + 1], j);
-			currentNodeCount++;
-		}
-		convertKillzone(triggerData->killzones[i], model->nodes[killzoneNodeIndex + i + killzoneChildCount], i);
-		currentNodeCount++;
-		killzoneChildCount += triggerData->killzones[i].triggerCount;
-		model->scenes[0].nodes.push_back(killzoneNodeIndex + i + killzoneChildCount - triggerData->killzones[i].triggerCount);
-	}
-
+	
 	// Remaining GenericRegion nodes
 	int genericRegionNodeIndex = currentNodeCount;
 	int currentGenericRegionNode = 0;
 	for (int i = 0; i < triggerData->genericRegionCount; ++i)
 	{
-		if (!triggerRegionExists(triggerData->genericRegions[i], false))
+		if ((uint8_t)triggerData->genericRegions[i].type == typeFilter)
 		{
 			model->nodes.push_back(Node());
 			model->nodes.back().mesh = 0;
@@ -330,42 +263,6 @@ void Converter::convertTriggersToGLTF()
 			currentGenericRegionNode++;
 			currentNodeCount++;
 		}
-	}
-
-	// Remaining TriggerRegion nodes
-	int triggerRegionNodeIndex = currentNodeCount;
-	int currentTriggerRegionNode = 0;
-	for (int i = 0; i < triggerData->regionCount; ++i)
-	{
-		if (!triggerRegionExists(triggerData->getRegion(i)))
-		{
-			model->nodes.push_back(Node());
-			model->nodes.back().mesh = 0;
-			convertTriggerRegion(triggerData->getRegion(i), model->nodes[triggerRegionNodeIndex + currentTriggerRegionNode], i);
-			model->scenes[0].nodes.push_back(triggerRegionNodeIndex + currentTriggerRegionNode);
-			currentTriggerRegionNode++;
-			currentNodeCount++;
-		}
-	}
-
-	// Point triggers
-	int roamingLocationNodeIndex = currentNodeCount;
-	for (int i = 0; i < triggerData->roamingLocationCount; ++i)
-	{
-		model->nodes.push_back(Node());
-		model->nodes.back().mesh = 0;
-		convertRoamingLocation(triggerData->roamingLocations[i], model->nodes[roamingLocationNodeIndex + i], i);
-		currentNodeCount++;
-		model->scenes[0].nodes.push_back(roamingLocationNodeIndex + i);
-	}
-	int spawnLocationNodeIndex = currentNodeCount;
-	for (int i = 0; i < triggerData->spawnLocationCount; ++i)
-	{
-		model->nodes.push_back(Node());
-		model->nodes.back().mesh = 0;
-		convertSpawnLocation(triggerData->spawnLocations[i], model->nodes[spawnLocationNodeIndex + i], i);
-		currentNodeCount++;
-		model->scenes[0].nodes.push_back(spawnLocationNodeIndex + i);
 	}
 
 	// Set up asset

--- a/src/converter.cpp
+++ b/src/converter.cpp
@@ -166,12 +166,12 @@ void Converter::writeBoxRegion(DataStream& stream)
 // Modified from https://stackoverflow.com/a/70462919
 Vector4 Converter::EulerToQuatRot(Vector3 euler)
 {
-	float cy = (float)qCos(euler.getZ() * 0.5);
-	float sy = (float)qSin(euler.getZ() * 0.5);
-	float cp = (float)qCos(euler.getY() * 0.5);
-	float sp = (float)qSin(euler.getY() * 0.5);
-	float cr = (float)qCos(euler.getX() * 0.5);
-	float sr = (float)qSin(euler.getX() * 0.5);
+	float cy = (float)qCos(euler.z * 0.5);
+	float sy = (float)qSin(euler.z * 0.5);
+	float cp = (float)qCos(euler.y * 0.5);
+	float sp = (float)qSin(euler.y * 0.5);
+	float cr = (float)qCos(euler.x * 0.5);
+	float sr = (float)qSin(euler.x * 0.5);
 
 	return Vector4(
 		sr * cp * cy + cr * sp * sy,
@@ -242,38 +242,38 @@ void Converter::convertTriggersToGLTF()
 	int currentNodeCount = 0;
 	int landmarkNodeIndex = currentNodeCount;
 	int landmarkChildCount = 0;
-	for (int i = 0; i < triggerData->getLandmarkCount(); ++i)
+	for (int i = 0; i < triggerData->landmarkCount; ++i)
 	{
 		model->nodes.push_back(Node());
 		model->nodes.back().mesh = 0;
-		for (int j = 0; j < triggerData->getLandmark(i).getStartingGridCount(); ++j)
+		for (int j = 0; j < triggerData->landmarks[i].startingGridCount; ++j)
 		{
 			model->nodes.push_back(Node());
 			model->nodes.back().mesh = 0;
 			model->nodes[landmarkNodeIndex + i + landmarkChildCount].children.push_back(landmarkNodeIndex + i + landmarkChildCount + j + 1);
-			convertStartingGrid(triggerData->getLandmark(i).getStartingGrid(j), model->nodes[landmarkNodeIndex + i + landmarkChildCount + j + 1], j);
+			convertStartingGrid(triggerData->landmarks[i].startingGrids[j], model->nodes[landmarkNodeIndex + i + landmarkChildCount + j + 1], j);
 			currentNodeCount++;
 		}
-		convertLandmark(triggerData->getLandmark(i), model->nodes[i + landmarkNodeIndex], i);
+		convertLandmark(triggerData->landmarks[i], model->nodes[i + landmarkNodeIndex], i);
 		currentNodeCount++;
-		landmarkChildCount += triggerData->getLandmark(i).getStartingGridCount();
-		model->scenes[0].nodes.push_back(landmarkNodeIndex + i + landmarkChildCount - triggerData->getLandmark(i).getStartingGridCount());
+		landmarkChildCount += triggerData->landmarks[i].startingGridCount;
+		model->scenes[0].nodes.push_back(landmarkNodeIndex + i + landmarkChildCount - triggerData->landmarks[i].startingGridCount);
 	}
 	int blackspotNodeIndex = currentNodeCount;
-	for (int i = 0; i < triggerData->getBlackspotCount(); ++i)
+	for (int i = 0; i < triggerData->blackspotCount; ++i)
 	{
 		model->nodes.push_back(Node());
 		model->nodes.back().mesh = 0;
-		convertBlackspot(triggerData->getBlackspot(i), model->nodes[blackspotNodeIndex + i], i);
+		convertBlackspot(triggerData->blackspots[i], model->nodes[blackspotNodeIndex + i], i);
 		currentNodeCount++;
 		model->scenes[0].nodes.push_back(blackspotNodeIndex + i);
 	}
 	int vfxBoxRegionNodeIndex = currentNodeCount;
-	for (int i = 0; i < triggerData->getVfxBoxRegionCount(); ++i)
+	for (int i = 0; i < triggerData->vfxBoxRegionCount; ++i)
 	{
 		model->nodes.push_back(Node());
 		model->nodes.back().mesh = 0;
-		convertVfxBoxRegion(triggerData->getVfxBoxRegion(i), model->nodes[vfxBoxRegionNodeIndex + i], i);
+		convertVfxBoxRegion(triggerData->vfxBoxRegions[i], model->nodes[vfxBoxRegionNodeIndex + i], i);
 		currentNodeCount++;
 		model->scenes[0].nodes.push_back(vfxBoxRegionNodeIndex + i);
 	}
@@ -281,51 +281,51 @@ void Converter::convertTriggersToGLTF()
 	// Nodes with GenericRegion arrays
 	int signatureStuntNodeIndex = currentNodeCount;
 	int signatureStuntChildCount = 0;
-	for (int i = 0; i < triggerData->getSignatureStuntCount(); ++i)
+	for (int i = 0; i < triggerData->signatureStuntCount; ++i)
 	{
 		model->nodes.push_back(Node());
-		for (int j = 0; j < triggerData->getSignatureStunt(i).getStuntElementCount(); ++j)
+		for (int j = 0; j < triggerData->signatureStunts[i].stuntElementCount; ++j)
 		{
 			model->nodes.push_back(Node());
 			model->nodes.back().mesh = 0;
 			model->nodes[signatureStuntNodeIndex + i + signatureStuntChildCount].children.push_back(signatureStuntNodeIndex + i + signatureStuntChildCount + j + 1);
-			convertGenericRegion(triggerData->getSignatureStunt(i).getStuntElement(j), model->nodes[signatureStuntNodeIndex + i + signatureStuntChildCount + j + 1], j);
+			convertGenericRegion(triggerData->signatureStunts[i].getStuntElement(j), model->nodes[signatureStuntNodeIndex + i + signatureStuntChildCount + j + 1], j);
 			currentNodeCount++;
 		}
-		convertSignatureStunt(triggerData->getSignatureStunt(i), model->nodes[signatureStuntNodeIndex + i + signatureStuntChildCount], i);
+		convertSignatureStunt(triggerData->signatureStunts[i], model->nodes[signatureStuntNodeIndex + i + signatureStuntChildCount], i);
 		currentNodeCount++;
-		signatureStuntChildCount += triggerData->getSignatureStunt(i).getStuntElementCount();
-		model->scenes[0].nodes.push_back(signatureStuntNodeIndex + i + signatureStuntChildCount - triggerData->getSignatureStunt(i).getStuntElementCount());
+		signatureStuntChildCount += triggerData->signatureStunts[i].stuntElementCount;
+		model->scenes[0].nodes.push_back(signatureStuntNodeIndex + i + signatureStuntChildCount - triggerData->signatureStunts[i].stuntElementCount);
 	}
 	int killzoneNodeIndex = currentNodeCount;
 	int killzoneChildCount = 0;
-	for (int i = 0; i < triggerData->getKillzoneCount(); ++i)
+	for (int i = 0; i < triggerData->killzoneCount; ++i)
 	{
 		model->nodes.push_back(Node());
-		for (int j = 0; j < triggerData->getKillzone(i).getTriggerCount(); ++j)
+		for (int j = 0; j < triggerData->killzones[i].triggerCount; ++j)
 		{
 			model->nodes.push_back(Node());
 			model->nodes.back().mesh = 0;
 			model->nodes[killzoneNodeIndex + i + killzoneChildCount].children.push_back(killzoneNodeIndex + i + killzoneChildCount + j + 1);
-			convertGenericRegion(triggerData->getKillzone(i).getTrigger(j), model->nodes[killzoneNodeIndex + i + killzoneChildCount + j + 1], j);
+			convertGenericRegion(triggerData->killzones[i].getTrigger(j), model->nodes[killzoneNodeIndex + i + killzoneChildCount + j + 1], j);
 			currentNodeCount++;
 		}
-		convertKillzone(triggerData->getKillzone(i), model->nodes[killzoneNodeIndex + i + killzoneChildCount], i);
+		convertKillzone(triggerData->killzones[i], model->nodes[killzoneNodeIndex + i + killzoneChildCount], i);
 		currentNodeCount++;
-		killzoneChildCount += triggerData->getKillzone(i).getTriggerCount();
-		model->scenes[0].nodes.push_back(killzoneNodeIndex + i + killzoneChildCount - triggerData->getKillzone(i).getTriggerCount());
+		killzoneChildCount += triggerData->killzones[i].triggerCount;
+		model->scenes[0].nodes.push_back(killzoneNodeIndex + i + killzoneChildCount - triggerData->killzones[i].triggerCount);
 	}
 
 	// Remaining GenericRegion nodes
 	int genericRegionNodeIndex = currentNodeCount;
 	int currentGenericRegionNode = 0;
-	for (int i = 0; i < triggerData->getGenericRegionCount(); ++i)
+	for (int i = 0; i < triggerData->genericRegionCount; ++i)
 	{
-		if (!triggerRegionExists(triggerData->getGenericRegion(i), false))
+		if (!triggerRegionExists(triggerData->genericRegions[i], false))
 		{
 			model->nodes.push_back(Node());
 			model->nodes.back().mesh = 0;
-			convertGenericRegion(triggerData->getGenericRegion(i), model->nodes[genericRegionNodeIndex + currentGenericRegionNode], i);
+			convertGenericRegion(triggerData->genericRegions[i], model->nodes[genericRegionNodeIndex + currentGenericRegionNode], i);
 			model->scenes[0].nodes.push_back(genericRegionNodeIndex + currentGenericRegionNode);
 			currentGenericRegionNode++;
 			currentNodeCount++;
@@ -335,13 +335,13 @@ void Converter::convertTriggersToGLTF()
 	// Remaining TriggerRegion nodes
 	int triggerRegionNodeIndex = currentNodeCount;
 	int currentTriggerRegionNode = 0;
-	for (int i = 0; i < triggerData->getRegionCount(); ++i)
+	for (int i = 0; i < triggerData->regionCount; ++i)
 	{
-		if (!triggerRegionExists(triggerData->getTriggerRegion(i)))
+		if (!triggerRegionExists(triggerData->getRegion(i)))
 		{
 			model->nodes.push_back(Node());
 			model->nodes.back().mesh = 0;
-			convertTriggerRegion(triggerData->getTriggerRegion(i), model->nodes[triggerRegionNodeIndex + currentTriggerRegionNode], i);
+			convertTriggerRegion(triggerData->getRegion(i), model->nodes[triggerRegionNodeIndex + currentTriggerRegionNode], i);
 			model->scenes[0].nodes.push_back(triggerRegionNodeIndex + currentTriggerRegionNode);
 			currentTriggerRegionNode++;
 			currentNodeCount++;
@@ -350,20 +350,20 @@ void Converter::convertTriggersToGLTF()
 
 	// Point triggers
 	int roamingLocationNodeIndex = currentNodeCount;
-	for (int i = 0; i < triggerData->getRoamingLocationCount(); ++i)
+	for (int i = 0; i < triggerData->roamingLocationCount; ++i)
 	{
 		model->nodes.push_back(Node());
 		model->nodes.back().mesh = 0;
-		convertRoamingLocation(triggerData->getRoamingLocation(i), model->nodes[roamingLocationNodeIndex + i], i);
+		convertRoamingLocation(triggerData->roamingLocations[i], model->nodes[roamingLocationNodeIndex + i], i);
 		currentNodeCount++;
 		model->scenes[0].nodes.push_back(roamingLocationNodeIndex + i);
 	}
 	int spawnLocationNodeIndex = currentNodeCount;
-	for (int i = 0; i < triggerData->getSpawnLocationCount(); ++i)
+	for (int i = 0; i < triggerData->spawnLocationCount; ++i)
 	{
 		model->nodes.push_back(Node());
 		model->nodes.back().mesh = 0;
-		convertSpawnLocation(triggerData->getSpawnLocation(i), model->nodes[spawnLocationNodeIndex + i], i);
+		convertSpawnLocation(triggerData->spawnLocations[i], model->nodes[spawnLocationNodeIndex + i], i);
 		currentNodeCount++;
 		model->scenes[0].nodes.push_back(spawnLocationNodeIndex + i);
 	}
@@ -383,44 +383,44 @@ void Converter::convertTriggersToGLTF()
 
 bool Converter::triggerRegionExists(TriggerRegion region, bool checkGenericRegions)
 {
-	int32_t id = region.getId();
-	for (int i = 0; i < triggerData->getLandmarkCount(); ++i)
+	int32_t id = region.id;
+	for (int i = 0; i < triggerData->landmarkCount; ++i)
 	{
-		if (id == triggerData->getLandmark(i).getId())
+		if (id == triggerData->landmarks[i].id)
 			return true;
 	}
-	for (int i = 0; i < triggerData->getBlackspotCount(); ++i)
+	for (int i = 0; i < triggerData->blackspotCount; ++i)
 	{
-		if (id == triggerData->getBlackspot(i).getId())
+		if (id == triggerData->blackspots[i].id)
 			return true;
 	}
-	for (int i = 0; i < triggerData->getVfxBoxRegionCount(); ++i)
+	for (int i = 0; i < triggerData->vfxBoxRegionCount; ++i)
 	{
-		if (id == triggerData->getVfxBoxRegion(i).getId())
+		if (id == triggerData->vfxBoxRegions[i].id)
 			return true;
 	}
 	if (checkGenericRegions)
 	{
-		for (int i = 0; i < triggerData->getGenericRegionCount(); ++i)
+		for (int i = 0; i < triggerData->genericRegionCount; ++i)
 		{
-			if (id == triggerData->getGenericRegion(i).getId())
+			if (id == triggerData->genericRegions[i].id)
 				return true;
 		}
 		return false;
 	}
-	for (int i = 0; i < triggerData->getSignatureStuntCount(); ++i)
+	for (int i = 0; i < triggerData->signatureStuntCount; ++i)
 	{
-		for (int j = 0; j < triggerData->getSignatureStunt(i).getStuntElementCount(); ++j)
+		for (int j = 0; j < triggerData->signatureStunts[i].stuntElementCount; ++j)
 		{
-			if (id == triggerData->getSignatureStunt(i).getStuntElement(j).getId())
+			if (id == triggerData->signatureStunts[i].getStuntElement(j).id)
 				return true;
 		}
 	}
-	for (int i = 0; i < triggerData->getKillzoneCount(); ++i)
+	for (int i = 0; i < triggerData->killzoneCount; ++i)
 	{
-		for (int j = 0; j < triggerData->getKillzone(i).getTriggerCount(); ++j)
+		for (int j = 0; j < triggerData->killzones[i].triggerCount; ++j)
 		{
-			if (id == triggerData->getKillzone(i).getTrigger(j).getId())
+			if (id == triggerData->killzones[i].getTrigger(j).id)
 				return true;
 		}
 	}
@@ -429,10 +429,10 @@ bool Converter::triggerRegionExists(TriggerRegion region, bool checkGenericRegio
 
 void Converter::addTriggerRegionFields(TriggerRegion region, Value::Object& extras)
 {
-	extras["TriggerRegion ID"] = Value(region.getId());
-	extras["TriggerRegion region index"] = Value(region.getRegionIndex());
-	extras["TriggerRegion type"] = Value((uint8_t)region.getType());
-	extras["TriggerRegion unknown 0"] = Value(region.getUnk0());
+	extras["TriggerRegion ID"] = Value(region.id);
+	extras["TriggerRegion region index"] = Value(region.regionIndex);
+	extras["TriggerRegion type"] = Value((uint8_t)region.type);
+	extras["TriggerRegion unknown 0"] = Value(region.unk0);
 }
 
 void Converter::convertLandmark(Landmark landmark, Node& node, int index)
@@ -441,18 +441,18 @@ void Converter::convertLandmark(Landmark landmark, Node& node, int index)
 
 	Value::Object extras;
 	addTriggerRegionFields(landmark, extras);
-	extras["Design index"] = Value(landmark.getDesignIndex());
-	extras["District"] = Value(landmark.getDistrict());
-	extras["Is online"] = Value(landmark.getIsOnline());
+	extras["Design index"] = Value(landmark.designIndex);
+	extras["District"] = Value(landmark.district);
+	extras["Is online"] = Value((bool)(((uint8_t)landmark.flags & (uint8_t)Landmark::Flags::isOnline) != 0));
 	node.extras = Value(extras);
 
-	node.name = "Landmark " + std::to_string(index) + " (" + std::to_string(landmark.getId()) + ")";
+	node.name = "Landmark " + std::to_string(index) + " (" + std::to_string(landmark.id) + ")";
 }
 
 void Converter::convertStartingGrid(StartingGrid grid, Node& node, int index)
 {
 	for (int i = 0; i < 8; ++i)
-		addPointTransform(grid.getStartingPosition(i), grid.getStartingDirection(i), node);
+		addPointTransform(grid.startingPositions[i], grid.startingDirections[i], node);
 }
 
 void Converter::convertBlackspot(Blackspot blackspot, Node& node, int index)
@@ -461,35 +461,35 @@ void Converter::convertBlackspot(Blackspot blackspot, Node& node, int index)
 
 	Value::Object extras;
 	addTriggerRegionFields(blackspot, extras);
-	extras["Score type"] = Value((uint8_t)blackspot.getScoreType());
-	extras["Score amount"] = Value(blackspot.getScoreAmount());
+	extras["Score type"] = Value((uint8_t)blackspot.scoreType);
+	extras["Score amount"] = Value(blackspot.scoreAmount);
 	node.extras = Value(extras);
 
-	node.name = "Blackspot " + std::to_string(index) + " (" + std::to_string(blackspot.getId()) + ")";
+	node.name = "Blackspot " + std::to_string(index) + " (" + std::to_string(blackspot.id) + ")";
 }
 
 void Converter::convertVfxBoxRegion(VFXBoxRegion vfxBoxRegion, Node& node, int index)
 {
 	addBoxRegionTransform(vfxBoxRegion, node);
 
-	node.name = "VFXBoxRegion " + std::to_string(index) + " (" + std::to_string(vfxBoxRegion.getId()) + ")";
+	node.name = "VFXBoxRegion " + std::to_string(index) + " (" + std::to_string(vfxBoxRegion.id) + ")";
 }
 
 void Converter::convertSignatureStunt(SignatureStunt signatureStunt, Node& node, int index)
 {
 	Value::Object extras;
-	extras["ID"] = Value((int)signatureStunt.getId());
-	extras["Camera"] = Value((int)signatureStunt.getCamera());
+	extras["ID"] = Value((int)signatureStunt.id);
+	extras["Camera"] = Value((int)signatureStunt.camera);
 	node.extras = Value(extras);
 
-	node.name = "SignatureStunt " + std::to_string(index) + " (" + std::to_string(signatureStunt.getId()) + ")";
+	node.name = "SignatureStunt " + std::to_string(index) + " (" + std::to_string(signatureStunt.id) + ")";
 }
 
 void Converter::convertKillzone(Killzone killzone, Node& node, int index)
 {
 	Value::Array regionIds;
-	for (int i = 0; i < killzone.getRegionIdCount(); ++i)
-		regionIds.push_back(Value((int)killzone.getRegionId(i)));
+	for (int i = 0; i < killzone.regionIdCount; ++i)
+		regionIds.push_back(Value((int)killzone.regionIds[i]));
 
 	Value::Object extras;
 	extras["Region IDs"] = Value(regionIds);
@@ -504,18 +504,18 @@ void Converter::convertGenericRegion(GenericRegion region, Node& node, int index
 
 	Value::Object extras;
 	addTriggerRegionFields(region, extras);
-	extras["Group ID"] = Value(region.getGroupId());
-	extras["Camera cut 1"] = Value(region.getCameraCut1());
-	extras["Camera cut 2"] = Value(region.getCameraCut2());
-	extras["Camera type 1"] = Value((int16_t)region.getcameraType1());
-	extras["Camera type 2"] = Value((int16_t)region.getcameraType2());
-	extras["Type"] = Value((uint8_t)region.getType());
-	extras["Is one way"] = Value((bool)region.getIsOneWay());
+	extras["Group ID"] = Value(region.groupId);
+	extras["Camera cut 1"] = Value(region.cameraCut1);
+	extras["Camera cut 2"] = Value(region.cameraCut2);
+	extras["Camera type 1"] = Value((int16_t)region.cameraType1);
+	extras["Camera type 2"] = Value((int16_t)region.cameraType2);
+	extras["Type"] = Value((uint8_t)region.type);
+	extras["Is one way"] = Value((bool)region.isOneWay);
 	node.extras = Value(extras);
 
-	uint64_t id = region.getGroupId();
+	uint64_t id = region.groupId;
 	if (id == 0)
-		id = region.getId();
+		id = region.id;
 	node.name = "GenericRegion " + std::to_string(index) + " (" + std::to_string(id) + ")";
 }
 
@@ -523,15 +523,15 @@ void Converter::convertTriggerRegion(TriggerRegion triggerRegion, Node& node, in
 {
 	addBoxRegionTransform(triggerRegion, node);
 
-	node.name = "TriggerRegion " + std::to_string(index) + " (" + std::to_string(triggerRegion.getId()) + ")";
+	node.name = "TriggerRegion " + std::to_string(index) + " (" + std::to_string(triggerRegion.id) + ")";
 }
 
 void Converter::convertRoamingLocation(RoamingLocation location, Node& node, int index)
 {
-	addPointTransform(location.getPosition(), node);
+	addPointTransform(location.position, node);
 
 	Value::Object extras;
-	extras["District index"] = Value(location.getDistrictIndex());
+	extras["District index"] = Value(location.districtIndex);
 	node.extras = Value(extras);
 
 	node.name = "RoamingLocation " + std::to_string(index);
@@ -539,11 +539,11 @@ void Converter::convertRoamingLocation(RoamingLocation location, Node& node, int
 
 void Converter::convertSpawnLocation(SpawnLocation location, Node& node, int index)
 {
-	addPointTransform(location.getPosition(), location.getDirection(), node);
+	addPointTransform(location.position, location.direction, node);
 
 	Value::Object extras;
-	extras["Junkyard ID"] = Value((int)location.getJunkyardId());
-	extras["Type"] = Value((uint8_t)location.getType());
+	extras["Junkyard ID"] = Value((int)location.junkyardId);
+	extras["Type"] = Value((uint8_t)location.type);
 	node.extras = Value(extras);
 
 	node.name = "SpawnLocation " + std::to_string(index);

--- a/src/trigger-data.cpp
+++ b/src/trigger-data.cpp
@@ -7,8 +7,8 @@ void TriggerData::read(DataStream& file)
 	file >> versionNumber;
 	file >> size;
 	file.skip(0x8);
-	playerStartPosition.readVPU(file);
-	playerStartDirection.readVPU(file);
+	playerStartPosition.read(file);
+	playerStartDirection.read(file);
 	file >> landmarks;
 	file >> landmarkCount;
 	file >> onlineLandmarkCount;
@@ -49,66 +49,6 @@ void TriggerData::read(DataStream& file)
 	file.cAllocAndQtRead(regions, regionCount);
 	for (int i = 0; i < regionCount; ++i)
 		file.cAllocAndCustomRead(regions[i], 1);
-}
-
-Landmark TriggerData::getLandmark(int index)
-{
-	return landmarks[index];
-}
-
-SignatureStunt TriggerData::getSignatureStunt(int index)
-{
-	return signatureStunts[index];
-}
-
-GenericRegion TriggerData::getGenericRegion(int index)
-{
-	return genericRegions[index];
-}
-
-Killzone TriggerData::getKillzone(int index)
-{
-	return killzones[index];
-}
-
-Blackspot TriggerData::getBlackspot(int index)
-{
-	return blackspots[index];
-}
-
-VFXBoxRegion TriggerData::getVfxBoxRegion(int index)
-{
-	return vfxBoxRegions[index];
-}
-
-RoamingLocation TriggerData::getRoamingLocation(int index)
-{
-	return roamingLocations[index];
-}
-
-SpawnLocation TriggerData::getSpawnLocation(int index)
-{
-	return spawnLocations[index];
-}
-
-TriggerRegion TriggerData::getTriggerRegion(int index)
-{
-	return regions[index][0];
-}
-
-// Returns the number of box regions
-int32_t TriggerData::getTotalRegionCount()
-{
-	int signatureStuntRegionCount = 0;
-	for (int i = 0; i < signatureStuntCount; ++i)
-		signatureStuntRegionCount += signatureStunts[i].getStuntElementCount();
-
-	int killzoneRegionCount = 0;
-	for (int i = 0; i < killzoneCount; ++i)
-		killzoneRegionCount += killzones[i].getTriggerCount();
-
-	return landmarkCount + signatureStuntRegionCount + genericRegionCount
-		+ killzoneRegionCount + blackspotCount + vfxBoxRegionCount + regionCount;
 }
 
 void BoxRegion::read(DataStream& file)
@@ -152,17 +92,21 @@ void Landmark::read(DataStream& file)
 	file.seek(nextLandmark);
 }
 
-StartingGrid Landmark::getStartingGrid(int index)
+StartingGrid::StartingGrid()
 {
-	return startingGrids[index];
+	for (int i = 0; i < 8; ++i)
+	{
+		startingPositions[i] = Vector3(true);
+		startingDirections[i] = Vector3(true);
+	}
 }
 
 void StartingGrid::read(DataStream& file)
 {
 	for (int i = 0; i < 8; ++i)
-		startingPositions[i].readVPU(file);
+		startingPositions[i].read(file);
 	for (int i = 0; i < 8; ++i)
-		startingDirections[i].readVPU(file);
+		startingDirections[i].read(file);
 }
 
 void SignatureStunt::read(DataStream& file)
@@ -180,11 +124,6 @@ void SignatureStunt::read(DataStream& file)
 		file.cAllocAndCustomRead(stuntElements[i], 1);
 
 	file.seek(nextSignatureStunt);
-}
-
-GenericRegion SignatureStunt::getStuntElement(int index)
-{
-	return stuntElements[index][0];
 }
 
 void GenericRegion::read(DataStream& file)
@@ -233,15 +172,15 @@ void VFXBoxRegion::read(DataStream& file)
 
 void RoamingLocation::read(DataStream& file)
 {
-	position.readVPU(file);
+	position.read(file);
 	file >> districtIndex;
 	file.skip(0xF);
 }
 
 void SpawnLocation::read(DataStream& file)
 {
-	position.readVPU(file);
-	direction.readVPU(file);
+	position.read(file);
+	direction.read(file);
 	file >> junkyardId;
 	file >> type;
 	file.skip(0x7);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,0 +1,41 @@
+#include <types.h>
+
+Vector3::Vector3(bool isVpu)
+	: isVpu(isVpu)
+{
+
+}
+
+Vector3::Vector3(float x, float y, float z, bool isVpu)
+	: x(x), y(y), z(z), isVpu(isVpu)
+{
+	
+}
+
+void Vector3::read(DataStream& stream)
+{
+	stream >> x;
+	stream >> y;
+	stream >> z;
+	if (isVpu)
+		stream.skip(0x4);
+}
+
+Vector4::Vector4()
+{
+
+}
+
+Vector4::Vector4(float x, float y, float z, float w)
+	: x(x), y(y), z(z), w(w)
+{
+	
+}
+
+void Vector4::read(DataStream& stream)
+{
+	stream >> x;
+	stream >> y;
+	stream >> z;
+	stream >> w;
+}

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -21,6 +21,15 @@ void Vector3::read(DataStream& stream)
 		stream.skip(0x4);
 }
 
+void Vector3::write(DataStream& stream)
+{
+	stream << x;
+	stream << y;
+	stream << z;
+	if (isVpu)
+		stream.skip(0x4);
+}
+
 Vector4::Vector4()
 {
 
@@ -38,4 +47,12 @@ void Vector4::read(DataStream& stream)
 	stream >> y;
 	stream >> z;
 	stream >> w;
+}
+
+void Vector4::write(DataStream& stream)
+{
+	stream << x;
+	stream << y;
+	stream << z;
+	stream << w;
 }


### PR DESCRIPTION
Slightly expanded version of something I was working on a few months ago. When an integer matching a [GenericRegion type](https://burnout.wiki/wiki/Trigger_Data#BrnTrigger::GenericRegion::Type) is provided, the output GLTF will be filtered to only that type.

I've also added a largely untested option related to the above which reads a profile and limits the output GLTF to only the triggers (of the type specified by the filter) that haven't been collected on the save. In other words, it shows where the missing collectibles are. When overlaid with the game map, this can be pretty useful for finding stuff.

This also adds some old cleanup commits from the main branch that I didn't realize were there, so that's nice.